### PR TITLE
Added a GET and a POST route for orgABN

### DIFF
--- a/app_server/controllers/initial-render.js
+++ b/app_server/controllers/initial-render.js
@@ -1,9 +1,10 @@
 
 // Initial Page Render (Pug to HTML)
-module.exports.initialRender = function (req, res) { 
+module.exports.initialRender = function (req, res, orgABN) {
 
-  res.render('sentiment-analytics', { 
-    title: 'Sentiment Analytics'
+  res.render('sentiment-analytics', {
+    title: 'Sentiment Analytics',
+    orgABN: orgABN
   });  
 };
 

--- a/app_server/routes/index.js
+++ b/app_server/routes/index.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var bodyParser = require('body-parser');
 var router = express.Router();
 
 // Links to controller files:
@@ -8,13 +9,52 @@ var ctrlLoadResults  = require('../controllers/load-results');
 var ctrlResponseDetails = require('../controllers/response-details');
 var ctrlEntityTableDiagram = require('../controllers/entity-table-diagram');
 
+// ===============================================================================
+// ACCESS ROUTES
+// ===============================================================================
+
+
+let loadMasterPage = function (req, res) {
+	return loadAccessPost(req, res);
+};
+
+let loadAccessPost = function (req, res) {
+	let orgABN = req.body.orgABN;
+	if (orgABN == null)
+		orgABN = "master";
+	return ctrlInitialRender.initialRender(req, res, orgABN);
+};
+
+let loadAccessGet = function (req, res) {
+	let orgABN = req.query.orgABN;
+	if (orgABN == null)
+		orgABN = "master";
+	return ctrlInitialRender.initialRender(req, res, orgABN);
+};
+
+
+// ===============================================================================
+// ACCESS ROUTES
+// ===============================================================================
+
+// Support JSON Encoded Post Requests.
+
+router.use(bodyParser.json());
+router.use(express.json());
+
+// The post request access point.
+router.post('/load_access', loadAccessPost);
+router.get('/load_access', loadAccessGet);
+
 // GET & POST HTTP requests for the page:
-router.get('/', ctrlInitialRender.initialRender); // initial HTML load
+router.get('/', loadMasterPage); // initial HTML load
 router.post('/initial-queries', ctrlInitialQueries.getResults); // initial queries on page load
 router.post('/load-results', ctrlLoadResults.loadResults); // load non-interactive results
+
 // Fetch response details (in the histogram section):
-router.post('/response-details', ctrlResponseDetails.getResponse);   
+router.post('/response-details', ctrlResponseDetails.getResponse);
+
 // Fetch results for Entity Table and Entity Linkage Diagram:
-router.post('/entity-table-diagram', ctrlEntityTableDiagram.getResults);  
+router.post('/entity-table-diagram', ctrlEntityTableDiagram.getResults);
 
 module.exports = router;


### PR DESCRIPTION
Now the user can pass the orgABN via a GET query or POST JSON body.
The orgABN is propagated through to the initial-render JS and the sentiment-analytics.pug, but will need to be forwarded from there to the internal post requests.
The default value is 'master' and should be used if we would like to display all results.